### PR TITLE
Allow international phone numbers for reservations

### DIFF
--- a/testingassignment2/Models/CarRental.cs
+++ b/testingassignment2/Models/CarRental.cs
@@ -23,7 +23,7 @@ namespace testingassignment2.Models
         [Display(Name = "Email Address")]
         public string CustomerEmail { get; set; }
 
-        [Phone]
+        [RegularExpression(@"^[0-9+\-()\s]{7,20}$", ErrorMessage = "Please enter a valid contact number using digits, spaces, or +, -, ().")]
         [Display(Name = "Contact Number")]
         public string CustomerPhone { get; set; }
 


### PR DESCRIPTION
## Summary
- replace the strict phone attribute on car rentals with a regex that accepts common international formats
- keep client-side validation while allowing digits, spaces, and punctuation used by customers

## Testing
- not run (environment missing dotnet CLI)


------
https://chatgpt.com/codex/tasks/task_e_68d9b1a355a0833081ec0c9493bf5b17